### PR TITLE
[OPS-552] Updates to patterns and include MS licence

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     container: webhippie/golang
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Work around git permission issue
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: webhippie/golang
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Work around git permission issue
         run: |

--- a/cmd/check/IgnoreMSLicence-C#-style.txt
+++ b/cmd/check/IgnoreMSLicence-C#-style.txt
@@ -1,0 +1,8 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+code code code code code
+code code code code code
+code code code code code
+code code code code code
+code code code code code
+code code code code code

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -25,18 +25,24 @@ func check(e error) {
 
 func IsValidLicence(filepath string, licence_type string) (bool, error) {
 	licence, err := os.ReadFile(filepath)
-    
-	check(err)
-
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(-1)
+	}
 	var acceptedLicences []licensecheck.License
-    // Special exclude licence
-    acceptedLicences = append(acceptedLicences, licensecheck.License{Name: "IgnoreLicence", Text: ZepbenExcludeLicence})
+	// Special exclude licence
+	acceptedLicences = append(acceptedLicences, licensecheck.License{Name: "IgnoreLicence", Text: ZepbenExcludeLicence})
 
-	if licence_type == "private" {
+	// TODO: if the number of licences gets large, implement some looping maybe, or array-append
+	// Ignore the following licences
+	acceptedLicences = append(acceptedLicences, licensecheck.License{Name: "MicrosoftReciprocalLicence", Text: MicrosoftReciprocalLicence})
+
+	switch licence_type {
+	case "private":
 		acceptedLicences = append(acceptedLicences, licensecheck.License{Name: "ZepbenPrivate", Text: ZepbenPrivateLicence})
-	} else if licence_type == "public" {
+	case "public":
 		acceptedLicences = append(acceptedLicences, licensecheck.License{Name: "ZepbenPublic", Text: ZepbenPublicLicence})
-	} else {
+	default:
 		return false, fmt.Errorf("Wrong licence type '%s'! Use 'private' or 'public'", licence_type)
 	}
 
@@ -61,11 +67,37 @@ func IsValidLicence(filepath string, licence_type string) (bool, error) {
 // Should be used on either source files with licence headers or COPYING files.
 func main() {
 
-	valid, err := IsValidLicence(os.Args[1], os.Args[2])
-	if valid {
-		os.Exit(0)
+	var files []string
+	var err_files []string
+	var err error
+
+	if isFolder(os.Args[1]) {
+		files, err = FindFiles(os.Args[1])
+		if err != nil {
+			fmt.Println(err.Error())
+			os.Exit(-1)
+		}
+
+		for _, path := range files {
+			valid, err := IsValidLicence(path, os.Args[2])
+			if valid {
+				continue
+			} else {
+				fmt.Println(err.Error())
+				err_files = append(err_files, path)
+			}
+		}
+		fmt.Printf("Scanned %d files\n", len(files))
+		if len(err_files) != 0 {
+			os.Exit(-1)
+		}
 	} else {
-		fmt.Println(err.Error())
-		os.Exit(-1)
+		valid, err := IsValidLicence(os.Args[1], os.Args[2])
+		if valid {
+			os.Exit(0)
+		} else {
+			fmt.Println(err.Error())
+			os.Exit(-1)
+		}
 	}
 }

--- a/cmd/check/check_test.go
+++ b/cmd/check/check_test.go
@@ -27,6 +27,7 @@ func TestIsValidLicence(t *testing.T) {
 			{name: "Zepben Private shell-style", args: args{"ZepbenPrivate-shell-style.txt"}, want: true, wantErr: false},
 			{name: "Ignore licence shell-style", args: args{"IgnoreLicence-shell-style.txt"}, want: true, wantErr: false},
 			{name: "Ignore licence C-style", args: args{"IgnoreLicence-C-style.txt"}, want: true, wantErr: false},
+			{name: "Ignore MS reciprocal licence", args: args{"IgnoreMSLicence-C#-style.txt"}, want: true, wantErr: false},
 		},
 		"public": {
 			{name: "Zepben Public C-style", args: args{"ZepbenMPL-C-style.txt"}, want: true, wantErr: false},

--- a/cmd/check/files.go
+++ b/cmd/check/files.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+/*
+ * Copyright 2022 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * Licence, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+func isFolder(path string) bool {
+	// Get file info for the given path
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("Path '%s' does not exist.\n", path)
+		} else {
+			fmt.Printf("Error checking path '%s': %v\n", path, err)
+		}
+		return false
+	}
+
+	// Check if the path is a directory
+	if info.IsDir() {
+		return true
+	} else {
+		return false
+	}
+}
+
+func FindFiles(path string) ([]string, error) {
+
+	// Count the files and fill a list
+	var files []string
+	err := filepath.Walk(path, func(npath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("Can't read files from %s", path)
+		}
+
+		matched, _ := regexp.MatchString("(COPYING|LICENSE|.*\\.py|.*\\.java|.*\\.kt|.*\\.cs|.*\\.proto|.*\\.js|.*\\.ts)$", info.Name())
+		if matched && !info.IsDir() {
+			files = append(files, npath)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}

--- a/cmd/check/proprietary_licences.go
+++ b/cmd/check/proprietary_licences.go
@@ -13,3 +13,5 @@ const ZepbenPrivateLicence = `Copyright (c) Zeppelin Bend Pty Ltd (Zepben)
 - All Rights Reserved.
 Unauthorized use, copy, or distribution of this file or its contents, via any medium is strictly prohibited.
 `
+
+const MicrosoftReciprocalLicence = `// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.`


### PR DESCRIPTION
# Description

This change updates the licence-checker with the following:

1. It will use the provided path and:
  - if it's a file, run the checker
  - if it's a path, scan for all the patterns we usually check, find all the files and run the checker on them. If a file is found without a licence, output the name and _continue_ the search.
2. Add an MS Reciprocal licence to the list of excluded licences.